### PR TITLE
Composer 2.0 will not support uppercase characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The package's installation is done using composer. Simply add these lines to you
 ```json
 {
     "require": {
-        "ProcessOut/ProcessOut-php": "^6.14.0"
+        "processOut/processout-php": "^6.14.0"
     }
 }
 ```


### PR DESCRIPTION
Starting from Composer 1.9 a Deprecation warning is thrown:

> Deprecation warning: require.ProcessOut/ProcessOut-php is invalid, it should not contain uppercase characters. Please use processout/processout-php instead. Make sure you fix this as Composer 2.0 will error.